### PR TITLE
Add assertions for task index validation in DeleteCommand, MarkComman…

### DIFF
--- a/src/main/java/bearbot/commands/DeleteCommand.java
+++ b/src/main/java/bearbot/commands/DeleteCommand.java
@@ -34,9 +34,7 @@ public class DeleteCommand extends Command {
      */
     @Override
     public String execute() throws BearBotException {
-        if (index < 0 || index >= taskList.getSize()) {
-            throw new BearBotException("Task index is out of range!");
-        }
+        assert index >= 0 && index < taskList.getSize() : "Task index is out of range";
 
         Task toRemove = taskList.getOneTask(index);
         taskList.removeTask(index);

--- a/src/main/java/bearbot/commands/MarkCommand.java
+++ b/src/main/java/bearbot/commands/MarkCommand.java
@@ -32,9 +32,8 @@ public class MarkCommand extends Command {
      */
     @Override
     public String execute() throws BearBotException {
-        if (index < 0 || index >= taskList.getSize()) {
-            throw new BearBotException("Task index is out of range!");
-        }
+        assert index >= 0 && index < taskList.getSize() : "Task index is out of range";
+
         taskList.markTask(index);
         return "Nice! I've marked this task as done:\n" + taskList.getOneTask(index);
     }

--- a/src/main/java/bearbot/commands/UnmarkCommand.java
+++ b/src/main/java/bearbot/commands/UnmarkCommand.java
@@ -33,9 +33,8 @@ public class UnmarkCommand extends Command {
      */
     @Override
     public String execute() throws BearBotException {
-        if (index < 0 || index >= taskList.getSize()) {
-            throw new BearBotException("Task index is out of range!");
-        }
+        assert index >= 0 && index < taskList.getSize() : "Task index is out of range";
+        
         taskList.unmarkTask(index);
         return "OK, I've marked this task as not done yet:\n" + taskList.getOneTask(index);
     }


### PR DESCRIPTION
Task index validation relies on exceptions to handle out-of-bounds cases before modifying the task list.

Using exceptions for index validation treats predictable issues as runtime errors rather than enforcing expected constraints. Assertions are more appropriate for assumptions that should always hold in normal execution.

Use assert statements in the following classes to validate task indices before accessing the task list.
- DeleteCommand
- MarkCommand
- UnmarkCommand

Assertions explicitly document assumptions about valid task indices and prevent invalid operations during development without affecting runtime performance in production.